### PR TITLE
Allow answers from guesses list using negative IDs

### DIFF
--- a/source/gameData.cpp
+++ b/source/gameData.cpp
@@ -511,17 +511,21 @@ void GameData::setPalettes(bool altPalette) const {
 }
 
 const std::u16string &GameData::getAnswer(time_t day) const {
-	const static std::u16string emptyString;
-
 	unsigned int index = (unsigned int)day - _firstDay;
 	if(_choiceOrder.size() > 0 && !settings->infiniteMode()) {
-		if(index < _choiceOrder.size())
-			return _choices[_choiceOrder[index] - 1];
-		else
-			return emptyString;
+		if(index < _choiceOrder.size()) {
+			int id = _choiceOrder[index];
+			if(id > 0 && id <= _choices.size())
+				return _choices[id - 1];
+			else if(id < 0 && id >= -_guesses.size())
+				return _guesses[-id - 1];
+		}
 	} else {
 		return _choices[index % _choices.size()];
 	}
+
+	const static std::u16string emptyString;
+	return emptyString;
 }
 
 void GameData::appendChoiceOrder(const std::vector<int> &ids) {

--- a/source/gameData.cpp
+++ b/source/gameData.cpp
@@ -317,11 +317,12 @@ GameData::GameData(const std::string &folder) : _modPath(DATA_PATH + folder) {
 
 			if(json["words"].contains("order") && json["words"]["order"].isArray()) {
 				_choiceOrder.clear();
+				const int choiceCount = (int)_choices.size();
+				const int guessCount = -(int)_guesses.size(); // Guess counts are indicated by negatives
 				for(const Json &word : json["words"]["order"]) {
 					int i = word.get()->valueint;
-					if(i >= 1 && i < (int)_choices.size()) {
-						_choiceOrder.push_back(i);
-					}
+					sassert((i >= 1 && i <= choiceCount) || (i <= -1 && i >= guessCount), "Invalid choice order ID\n\n(ID %d)", i);
+					_choiceOrder.push_back(i);
 				}
 			}
 
@@ -515,9 +516,9 @@ const std::u16string &GameData::getAnswer(time_t day) const {
 	if(_choiceOrder.size() > 0 && !settings->infiniteMode()) {
 		if(index < _choiceOrder.size()) {
 			int id = _choiceOrder[index];
-			if(id > 0 && id <= _choices.size())
+			if(id > 0 && id <= (int)_choices.size())
 				return _choices[id - 1];
-			else if(id < 0 && id >= -_guesses.size())
+			else if(id < 0 && id >= -(int)_guesses.size())
 				return _guesses[-id - 1];
 		}
 	} else {

--- a/source/wifi.cpp
+++ b/source/wifi.cpp
@@ -99,8 +99,8 @@ void WiFi::getWords(const char *url) {
 			Gfx::showPopup(json["message"].get()->valuestring, 120);
 		} else if(json.isArray()) {
 			// Validate results
-			int choiceCount = game->data().choices().size();
-			int guessCount = -game->data().guesses().size(); // Guess list IDs are negative
+			const int choiceCount = game->data().choices().size();
+			const int guessCount = -game->data().guesses().size(); // Guess list IDs are negative
 			std::vector<int> ids;
 			for(const Json id : json) {
 				if(id.isNumber()) {

--- a/source/wifi.cpp
+++ b/source/wifi.cpp
@@ -100,12 +100,17 @@ void WiFi::getWords(const char *url) {
 		} else if(json.isArray()) {
 			// Validate results
 			int choiceCount = game->data().choices().size();
+			int guessCount = -game->data().guesses().size(); // Guess list IDs are negative
 			std::vector<int> ids;
 			for(const Json id : json) {
-				if(id.isNumber() && id.get()->valueint >= 1 && id.get()->valueint <= choiceCount) {
-					ids.push_back(id.get()->valueint);
+				if(id.isNumber()) {
+					int val = id.get()->valueint;
+					if((val >= 1 && val <= choiceCount) || (val <= -1 && val >= guessCount))
+						ids.push_back(id.get()->valueint);
+					else
+						Gfx::showPopup("Error: Invalid ID", 120);
 				} else {
-					Gfx::showPopup("Error loading IDs", 120);
+					Gfx::showPopup("Error: Non-numeric ID", 120);
 					return;
 				}
 			}


### PR DESCRIPTION
Wordle 646 (iirc) uses an answer from the old 'guessable but not correct' list, I cannot simply merge the two lists as that would ruin infinite mode so instead I'm making it so a negative word ID will be a word in the guesses list.

- [x] Client side support for negative IDs
- [x] Server side support for negative IDs
- [x] Test that this code actually works